### PR TITLE
Dynamic heat sizes

### DIFF
--- a/app/app/pods/event/template.emblem
+++ b/app/app/pods/event/template.emblem
@@ -9,6 +9,7 @@
         p.players = player
     .heat-container
       h2 Heats
+      = input class="heat-size-input" type="text" value=heatSize placeholder="Number of Players in a Heat"
       button.generate-heats click="generateHeats" Generate Heats
       each heats as |heat|
         h3.heat heat

--- a/app/tests/integration/event/event-test.coffee
+++ b/app/tests/integration/event/event-test.coffee
@@ -14,15 +14,15 @@ describe "Integration: EventPage", ->
 
   describe "adding players", ->
     it "can add a new player", ->
-      expect(@page.numPlayers).to.equal 3
+      expect(@page.players().toArray().length).to.equal 3
 
       @addPlayer("derp")
 
       andThen =>
-        expect(@page.numPlayers).to.equal 4
+        expect(@page.players().toArray().length).to.equal 4
         expect(@page.playerInputValue).to.equal ""
 
-  describe.only "adding heats", ->
+  describe "adding heats", ->
     it "can generate basic heats", ->
       expect(@page.heats().toArray().length).to.equal 0
 
@@ -35,3 +35,15 @@ describe "Integration: EventPage", ->
         expect(@page.heats().toArray().length).to.equal 2
         expect(@page.heatsPlayers().toArray().length).to.equal 6
         #TODO Expect unique players for the heats
+
+  # dependent on previous test until we can figure out how to reset the model/controller
+  describe "dynamic number of players per heat", ->
+    it "changes number of players per heat", ->
+      expect(@page.heats().toArray().length).to.equal 2
+
+      @page.setHeatSize(2)
+      @page.generateHeats()
+
+      andThen =>
+        expect(@page.heats().toArray().length).to.equal 3
+        expect(@page.heatsPlayers().toArray().length).to.equal 6

--- a/app/tests/pages/event.coffee
+++ b/app/tests/pages/event.coffee
@@ -8,6 +8,7 @@ EventPage = PageObject.create
   generateHeats: clickable('.generate-heats')
   setPlayerName: fillable('.player-name-input')
   playerInputValue: value('.player-name-input')
+  setHeatSize: fillable('.heat-size-input')
 
   players: collection
     itemScope: '.players'


### PR DESCRIPTION
Added a text field to allow for different size heats and have tests to go with. The new test depends on the previous "generate heats" tests because I couldn't figure out to reload the page in the test framework in a way that 'reset' the model like a page refresh would. Will need to change later